### PR TITLE
feat: add cashu web interface with maud templates and split mint flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.31"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "jobserver",
  "libc",
@@ -869,6 +869,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "features"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83072b3c84e55f9d0c0ff36a4575d0fd2e543ae4a56e04e7f5a9222188d574e3"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fern"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashlink"
@@ -1406,7 +1415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -1595,6 +1604,28 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "memchr"
@@ -1820,6 +1851,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]
@@ -2155,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2414,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -2454,10 +2497,13 @@ dependencies = [
  "cdk",
  "cdk-sqlite",
  "chrono",
+ "clap 4.5.43",
+ "features",
  "hal",
  "hex 0.4.3",
  "home",
  "lazy_static",
+ "maud",
  "rand 0.9.2",
  "secp256k1 0.31.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ tower-http = { version = "0.6.2", features = ["cors"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 hex = "0.4.3"
 hal = "0.10.0"
+maud = "0.27.0"
+features = "0.10.0"
+clap = { version = "4.5.43", features = ["derive"] }
 
 [dependencies.secp256k1-musig]
 package = "secp256k1"

--- a/src/cashu_web.rs
+++ b/src/cashu_web.rs
@@ -1,0 +1,643 @@
+use axum::{
+    extract::{Form, State},
+    http::StatusCode,
+    response::{Html, Json},
+    routing::{get, post},
+    Router,
+};
+use maud::{html, Markup, PreEscaped, DOCTYPE};
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+use tower_http::cors::CorsLayer;
+
+use crate::cashu;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub mint_url: String,
+}
+
+#[derive(Deserialize)]
+struct MintForm {
+    amount: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct TokenForm {
+    amount: u64,
+}
+
+#[derive(Deserialize)]
+struct CompleteMintForm {
+    quote_id: String,
+}
+
+pub fn create_cashu_app(mint_url: String) -> Router {
+    let state = AppState { mint_url };
+    
+    Router::new()
+        .route("/", get(index))
+        .route("/mint", post(handle_mint))
+        .route("/mint-quote", post(create_mint_quote_handler))
+        .route("/complete-mint", post(complete_mint_handler))
+        .route("/balance", get(get_balance))
+        .route("/token", post(create_token))
+        .layer(CorsLayer::permissive())
+        .with_state(Arc::new(state))
+}
+
+fn base_template(title: &str, content: Markup, balance: u64) -> Markup {
+    html! {
+        (DOCTYPE)
+        html {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) }
+                style {
+                    (PreEscaped(r#"
+                        :root {
+                            font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+                            line-height: 1.5;
+                            font-weight: 400;
+                            color-scheme: light dark;
+                            color: rgba(255, 255, 255, 0.87);
+                            background-color: #242424;
+                            font-synthesis: none;
+                            text-rendering: optimizeLegibility;
+                            -webkit-font-smoothing: antialiased;
+                            -moz-osx-font-smoothing: grayscale;
+                        }
+                        
+                        body {
+                            margin: 0;
+                            display: flex;
+                            flex-direction: column;
+                            place-items: center;
+                            min-width: 320px;
+                            min-height: 100vh;
+                            padding: 20px;
+                            position: relative;
+                        }
+                        
+                        .balance-corner {
+                            position: fixed;
+                            top: 20px;
+                            right: 20px;
+                            font-size: 1em;
+                            padding: 0.6em 1em;
+                            background: #1a1a1a;
+                            border-radius: 8px;
+                            border: 1px solid #646cff;
+                            z-index: 1000;
+                            box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+                        }
+                        
+                        .balance-corner h2 {
+                            margin: 0 0 0.2em 0;
+                            font-size: 0.9em;
+                            opacity: 0.8;
+                        }
+                        
+                        .balance-corner div {
+                            margin: 0;
+                            font-weight: bold;
+                            font-size: 1.1em;
+                        }
+                        
+                        #root {
+                            max-width: 1280px;
+                            margin: 0 auto;
+                            padding: 1rem;
+                            text-align: center;
+                        }
+                        
+                        h1 {
+                            font-size: 2.5em;
+                            line-height: 1.1;
+                            margin-bottom: 0.5em;
+                        }
+                        
+                        h2 {
+                            font-size: 1.5em;
+                            margin-bottom: 0.5em;
+                        }
+                        
+                        .card {
+                            padding: 1.5em;
+                            margin: 0.8em 0;
+                            background: #333;
+                            border-radius: 8px;
+                            border: 1px solid #444;
+                        }
+                        
+                        .card.compact {
+                            padding: 1em;
+                            margin: 0.5em 0;
+                        }
+                        
+                        button {
+                            border-radius: 8px;
+                            border: 1px solid transparent;
+                            padding: 0.6em 1.2em;
+                            font-size: 1em;
+                            font-weight: 500;
+                            font-family: inherit;
+                            background-color: #007bff;
+                            color: white;
+                            cursor: pointer;
+                            transition: background-color 0.25s;
+                            margin: 0.5em;
+                        }
+                        
+                        button:hover {
+                            background-color: #0056b3;
+                        }
+                        
+                        button:focus,
+                        button:focus-visible {
+                            outline: 4px auto -webkit-focus-ring-color;
+                        }
+                        
+                        button:disabled {
+                            opacity: 0.6;
+                            cursor: not-allowed;
+                            background-color: #666;
+                        }
+                        
+                        button:disabled:hover {
+                            background-color: #666;
+                        }
+                        
+                        input[type="number"] {
+                            padding: 0.6em 1.2em;
+                            font-size: 1em;
+                            border: 2px solid #ccc;
+                            border-radius: 8px;
+                            background-color: #333;
+                            color: white;
+                            margin: 0.5em;
+                        }
+                        
+                        textarea {
+                            width: 100%;
+                            max-width: 600px;
+                            padding: 15px;
+                            font-size: 16px;
+                            border: 2px solid #ccc;
+                            border-radius: 8px;
+                            background-color: #333;
+                            color: white;
+                            resize: vertical;
+                            font-family: monospace;
+                        }
+                        
+                        .balance {
+                            font-size: 1.2em;
+                            margin: 0.5em 0;
+                            padding: 0.8em;
+                            background: #1a1a1a;
+                            border-radius: 8px;
+                            border: 1px solid #646cff;
+                            display: inline-block;
+                            min-width: 200px;
+                        }
+                        
+                        .balance h2 {
+                            margin: 0 0 0.3em 0;
+                            font-size: 1.1em;
+                        }
+                        
+                        .balance div {
+                            margin: 0;
+                            font-weight: bold;
+                        }
+                        
+                        .form-group {
+                            margin: 1em 0;
+                            display: flex;
+                            flex-direction: column;
+                            align-items: center;
+                        }
+                        
+                        .success {
+                            color: #28a745;
+                            margin: 1em 0;
+                            padding: 1em;
+                            background: #1a1a1a;
+                            border-radius: 8px;
+                            border: 1px solid #28a745;
+                        }
+                        
+                        .error {
+                            color: #dc3545;
+                            margin: 1em 0;
+                            padding: 1em;
+                            background: #1a1a1a;
+                            border-radius: 8px;
+                            border: 1px solid #dc3545;
+                        }
+                        
+                        @media (prefers-color-scheme: light) {
+                            :root {
+                                color: #213547;
+                                background-color: #ffffff;
+                            }
+                            
+                            .card {
+                                background: #f9f9f9;
+                                border-color: #ddd;
+                            }
+                            
+                            input[type="number"],
+                            textarea {
+                                background-color: #ffffff;
+                                color: #213547;
+                            }
+                            
+                            .balance {
+                                background: #f0f0f0;
+                            }
+                            
+                            .balance-corner {
+                                background: #f0f0f0;
+                                color: #213547;
+                                border-color: #646cff;
+                                box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+                            }
+                            
+                            .success {
+                                background: #f0f0f0;
+                            }
+                            
+                            .error {
+                                background: #f0f0f0;
+                            }
+                        }
+                    "#))
+                }
+            }
+            body {
+                div class="balance-corner" {
+                    h2 { "Balance" }
+                    div { 
+                        span id="balance-value" { (balance) }
+                        " sats"
+                    }
+                }
+                div id="root" {
+                    (content)
+                }
+                script {
+                    (PreEscaped(r#"
+                        async function refreshBalance() {
+                            try {
+                                const response = await fetch('/balance');
+                                const data = await response.json();
+                                const balanceElement = document.getElementById('balance-value');
+                                if (balanceElement) {
+                                    balanceElement.textContent = data.balance;
+                                }
+                            } catch (error) {
+                                console.error('Failed to refresh balance:', error);
+                            }
+                        }
+                        
+                        function copyToClipboard(text) {
+                            navigator.clipboard.writeText(text).then(() => {
+                                const button = event.target;
+                                const originalText = button.textContent;
+                                button.textContent = 'Copied!';
+                                setTimeout(() => {
+                                    button.textContent = originalText;
+                                }, 1000);
+                            });
+                        }
+                        
+                        async function completeMint(quoteId) {
+                            const button = event.target;
+                            const originalText = button.textContent;
+                            
+                            // Disable button and show loading state
+                            button.disabled = true;
+                            button.textContent = 'Checking Payment...';
+                            
+                            try {
+                                const response = await fetch('/complete-mint', {
+                                    method: 'POST',
+                                    headers: {
+                                        'Content-Type': 'application/x-www-form-urlencoded',
+                                    },
+                                    body: 'quote_id=' + encodeURIComponent(quoteId)
+                                });
+                                
+                                if (response.ok) {
+                                    // Show success message briefly then redirect to home
+                                    button.textContent = 'Mint Completed!';
+                                    setTimeout(() => {
+                                        window.location.href = '/';
+                                    }, 1500);
+                                } else {
+                                    // Handle error
+                                    button.textContent = 'Payment Not Found - Try Again';
+                                    button.disabled = false;
+                                    setTimeout(() => {
+                                        button.textContent = originalText;
+                                    }, 3000);
+                                }
+                            } catch (error) {
+                                console.error('Error completing mint:', error);
+                                button.textContent = 'Error - Try Again';
+                                button.disabled = false;
+                                setTimeout(() => {
+                                    button.textContent = originalText;
+                                }, 3000);
+                            }
+                        }
+                        
+                        // Auto-refresh balance every 10 seconds
+                        setInterval(refreshBalance, 10000);
+                    "#))
+                }
+            }
+        }
+    }
+}
+
+async fn index(State(state): State<Arc<AppState>>) -> Html<String> {
+    let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+    
+    let content = html! {
+        h1 { "SpillCash - Cashu Wallet" }
+        
+        div class="card compact" {
+            h2 { "Mint Configuration" }
+            p { "Connected to: " (state.mint_url) }
+        }
+        
+        div class="card" {
+            h2 { "Mint Ecash" }
+            form action="/mint-quote" method="post" {
+                div class="form-group" {
+                    label for="mint-amount" { "Amount (sats):" }
+                    input type="number" id="mint-amount" name="amount" placeholder="1000" min="1";
+                }
+                button type="submit" { "Get Lightning Invoice" }
+            }
+        }
+        
+        div class="card" {
+            h2 { "Create Token" }
+            form action="/token" method="post" {
+                div class="form-group" {
+                    label for="token-amount" { "Amount (sats):" }
+                    input type="number" id="token-amount" name="amount" placeholder="100" min="1" required;
+                }
+                button type="submit" { "Create Token" }
+            }
+        }
+    };
+    
+    Html(base_template("SpillCash - Cashu Wallet", content, balance).into_string())
+}
+
+async fn handle_mint(State(state): State<Arc<AppState>>, Form(form): Form<MintForm>) -> Result<Html<String>, StatusCode> {
+    match cashu::mint(form.amount, &state.mint_url).await {
+        Ok(_) => {
+            let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+            let content = html! {
+                h1 { "SpillCash - Cashu Wallet" }
+                
+                div class="success" {
+                    h2 { "✓ Mint Successful!" }
+                    p { "Minted " (form.amount.unwrap_or(1000)) " sats successfully." }
+                }
+                
+                div class="card" {
+                    h2 { "Mint Ecash" }
+                    form action="/mint-quote" method="post" {
+                        div class="form-group" {
+                            label for="mint-amount" { "Amount (sats):" }
+                            input type="number" id="mint-amount" name="amount" placeholder="1000" min="1";
+                        }
+                        button type="submit" { "Get Lightning Invoice" }
+                    }
+                }
+                
+                div class="card" {
+                    h2 { "Create Token" }
+                    form action="/token" method="post" {
+                        div class="form-group" {
+                            label for="token-amount" { "Amount (sats):" }
+                            input type="number" id="token-amount" name="amount" placeholder="100" min="1" required;
+                        }
+                        button type="submit" { "Create Token" }
+                    }
+                }
+                
+                div {
+                    a href="/" { "← Back to Home" }
+                }
+            };
+            
+            Ok(Html(base_template("SpillCash - Mint Success", content, balance).into_string()))
+        }
+        Err(e) => {
+            let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+            let content = html! {
+                h1 { "SpillCash - Cashu Wallet" }
+                
+                div class="error" {
+                    h2 { "✗ Mint Failed" }
+                    p { "Error: " (e.to_string()) }
+                }
+                
+                div {
+                    a href="/" { "← Back to Home" }
+                }
+            };
+            
+            Ok(Html(base_template("SpillCash - Mint Error", content, balance).into_string()))
+        }
+    }
+}
+
+async fn get_balance(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
+    let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+    Json(json!({
+        "balance": balance
+    }))
+}
+
+async fn create_token(State(state): State<Arc<AppState>>, Form(form): Form<TokenForm>) -> Result<Html<String>, StatusCode> {
+    match cashu::get_token(form.amount, &state.mint_url).await {
+        Ok(token) => {
+            let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+            let content = html! {
+                h1 { "SpillCash - Cashu Wallet" }
+                
+                div class="success" {
+                    h2 { "✓ Token Created!" }
+                    p { "Created token for " (form.amount) " sats." }
+                }
+                
+                div class="card" {
+                    h2 { "Your Token" }
+                    textarea readonly rows="8" {
+                        (token)
+                    }
+                    button type="button" onclick={ "copyToClipboard('" (token) "')" } {
+                        "Copy Token"
+                    }
+                }
+                
+                div {
+                    a href="/" { "← Back to Home" }
+                }
+            };
+            
+            Ok(Html(base_template("SpillCash - Token Created", content, balance).into_string()))
+        }
+        Err(e) => {
+            let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+            let content = html! {
+                h1 { "SpillCash - Cashu Wallet" }
+                
+                div class="error" {
+                    h2 { "✗ Token Creation Failed" }
+                    p { "Error: " (e.to_string()) }
+                }
+                
+                div {
+                    a href="/" { "← Back to Home" }
+                }
+            };
+            
+            Ok(Html(base_template("SpillCash - Token Error", content, balance).into_string()))
+        }
+    }
+}
+
+async fn create_mint_quote_handler(State(state): State<Arc<AppState>>, Form(form): Form<MintForm>) -> Result<Html<String>, StatusCode> {
+    match cashu::create_mint_quote(form.amount, &state.mint_url).await {
+        Ok(quote) => {
+            let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+            let content = html! {
+                h1 { "SpillCash - Cashu Wallet" }
+                
+                div class="success" {
+                    h2 { "Lightning Invoice Generated" }
+                    p { "Amount: " (form.amount.unwrap_or(1000)) " sats" }
+                    p { "Please pay the Lightning invoice below:" }
+                }
+                
+                div class="card" {
+                    h2 { "Lightning Invoice" }
+                    textarea readonly rows="6" id="invoice" {
+                        (quote.request)
+                    }
+                    button type="button" onclick={ "copyToClipboard('" (quote.request) "')" } {
+                        "Copy Invoice"
+                    }
+                }
+                
+                div class="card" {
+                    h2 { "Complete Mint" }
+                    p { "After paying the invoice, click the button below to complete the mint:" }
+                    button type="button" onclick={ "completeMint('" (quote.id) "')" } {
+                        "Complete Mint"
+                    }
+                    p style="margin-top: 1em; font-size: 0.9em; color: #888;" { 
+                        "This button will check if your payment has been received and complete the minting process." 
+                    }
+                }
+                
+                div {
+                    a href="/" { "← Back to Home" }
+                }
+            };
+            
+            Ok(Html(base_template("SpillCash - Lightning Invoice", content, balance).into_string()))
+        }
+        Err(e) => {
+            let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+            let content = html! {
+                h1 { "SpillCash - Cashu Wallet" }
+                
+                div class="error" {
+                    h2 { "✗ Quote Creation Failed" }
+                    p { "Error: " (e.to_string()) }
+                }
+                
+                div {
+                    a href="/" { "← Back to Home" }
+                }
+            };
+            
+            Ok(Html(base_template("SpillCash - Quote Error", content, balance).into_string()))
+        }
+    }
+}
+
+async fn complete_mint_handler(State(state): State<Arc<AppState>>, Form(form): Form<CompleteMintForm>) -> Result<Html<String>, StatusCode> {
+    match cashu::complete_mint(&form.quote_id, &state.mint_url).await {
+        Ok(minted_amount) => {
+            let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+            let content = html! {
+                h1 { "SpillCash - Cashu Wallet" }
+                
+                div class="success" {
+                    h2 { "✓ Mint Completed!" }
+                    p { "Successfully minted " (minted_amount) " sats." }
+                }
+                
+                div class="card" {
+                    h2 { "Mint Ecash" }
+                    form action="/mint-quote" method="post" {
+                        div class="form-group" {
+                            label for="mint-amount" { "Amount (sats):" }
+                            input type="number" id="mint-amount" name="amount" placeholder="1000" min="1";
+                        }
+                        button type="submit" { "Get Lightning Invoice" }
+                    }
+                }
+                
+                div class="card" {
+                    h2 { "Create Token" }
+                    form action="/token" method="post" {
+                        div class="form-group" {
+                            label for="token-amount" { "Amount (sats):" }
+                            input type="number" id="token-amount" name="amount" placeholder="100" min="1" required;
+                        }
+                        button type="submit" { "Create Token" }
+                    }
+                }
+                
+                div {
+                    a href="/" { "← Back to Home" }
+                }
+            };
+            
+            Ok(Html(base_template("SpillCash - Mint Complete", content, balance).into_string()))
+        }
+        Err(e) => {
+            let balance = cashu::get_balance(&state.mint_url).await.unwrap_or(0);
+            let content = html! {
+                h1 { "SpillCash - Cashu Wallet" }
+                
+                div class="error" {
+                    h2 { "✗ Mint Failed" }
+                    p { "Error: " (e.to_string()) }
+                    p { "The invoice may not have been paid yet, or there was an error processing the payment." }
+                }
+                
+                div {
+                    a href="/" { "← Back to Home" }
+                }
+            };
+            
+            Ok(Html(base_template("SpillCash - Mint Error", content, balance).into_string()))
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,58 @@
-use bitcoin::secp256k1::{Keypair, PublicKey};
-use std::str::FromStr;
+use clap::Parser;
 
-use crate::cashu::mint;
-
-pub mod cashu;
+mod cashu;
+mod cashu_web;
 mod musig;
 mod tx;
 mod web;
 
+#[derive(Parser)]
+#[command(name = "spillcash")]
+#[command(about = "A Cashu wallet and payment processor")]
+struct Cli {
+    /// Mint URL to connect to
+    #[arg(short, long, default_value = "https://fake.thesimplekid.dev")]
+    mint: String,
+
+    /// Initial amount to mint (in sats)
+    #[arg(short, long, default_value = "100000")]
+    amount: u64,
+
+    /// API server port
+    #[arg(long, default_value = "3000")]
+    api_port: u16,
+
+    /// Cashu web interface port
+    #[arg(long, default_value = "3001")]
+    cashu_port: u16,
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Initialize cashu operations
-    mint(Some(100_000)).await?;
-    println!("SpillCash initialized!");
+    let cli = Cli::parse();
 
-    // Create and start the web server
-    let app = web::create_app();
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
+    println!("SpillCash starting with mint: {}", cli.mint);
 
-    axum::serve(listener, app).await?;
+    // Create the main web server (API)
+    let api_app = web::create_app(cli.mint.clone());
+    let api_listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", cli.api_port)).await?;
+
+    // Create the cashu web interface
+    let cashu_app = cashu_web::create_cashu_app(cli.mint.clone());
+    let cashu_listener =
+        tokio::net::TcpListener::bind(format!("0.0.0.0:{}", cli.cashu_port)).await?;
+
+    println!("API server running on http://localhost:{}", cli.api_port);
+    println!(
+        "Cashu web interface running on http://localhost:{}",
+        cli.cashu_port
+    );
+
+    // Run both servers concurrently
+    tokio::try_join!(
+        axum::serve(api_listener, api_app),
+        axum::serve(cashu_listener, cashu_app)
+    )?;
 
     Ok(())
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,16 +1,14 @@
 use crate::tx;
 use axum::{
     Router,
-    extract::Path,
-    http::StatusCode,
+    extract::State,
     response::Json,
     routing::{get, post},
 };
 use bitcoin::secp256k1::{Keypair, PublicKey};
 use bitcoin::{Transaction, consensus::deserialize};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::json;
-use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use tower_http::cors::CorsLayer;
@@ -18,6 +16,11 @@ use tower_http::cors::CorsLayer;
 use bitcoin::Amount;
 
 use crate::cashu;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub mint_url: String,
+}
 
 lazy_static::lazy_static! {
     static ref SERVER_PK: PublicKey = PublicKey::from_str("030c99c81e19622d30cc5fe697f65f03eed93bbf177df99065a2d1f3141dcd095e").unwrap();
@@ -31,12 +34,15 @@ lazy_static::lazy_static! {
     static ref CHANNEL_BALANCE: Mutex<Amount> = Mutex::new(Amount::ZERO);
 }
 
-pub fn create_app() -> Router {
+pub fn create_app(mint_url: String) -> Router {
+    let state = AppState { mint_url };
+
     Router::new()
         .route("/address", get(get_address))
         .route("/tx", post(submit_tx))
         .route("/token", post(get_token))
         .layer(CorsLayer::permissive())
+        .with_state(Arc::new(state))
 }
 
 async fn get_address() -> Json<serde_json::Value> {
@@ -55,8 +61,12 @@ async fn submit_tx(Json(payload): Json<TxRequest>) -> Json<serde_json::Value> {
     let mut tx = TX.lock().unwrap();
     *tx = Some(parsed.clone());
 
-	let spk = tx::create_spk(*SERVER_PK, USER_KEY.public_key());
-	let output_idx = parsed.output.iter().position(|o| o.script_pubkey == spk).unwrap();
+    let spk = tx::create_spk(*SERVER_PK, USER_KEY.public_key());
+    let output_idx = parsed
+        .output
+        .iter()
+        .position(|o| o.script_pubkey == spk)
+        .unwrap();
 
     *CHANNEL_AMT.lock().unwrap() = parsed.output[output_idx].value;
     *CHANNEL_BALANCE.lock().unwrap() = parsed.output[output_idx].value;
@@ -71,8 +81,14 @@ struct TokenRequest {
     amount: u64,
 }
 
-async fn get_token(Json(payload): Json<TokenRequest>) -> Json<serde_json::Value> {
-    let token = cashu::get_token(payload.amount).await.unwrap();
+async fn get_token(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<TokenRequest>,
+) -> Json<serde_json::Value> {
+    // Use the mint URL from the application state
+    let token = cashu::get_token(payload.amount, &state.mint_url)
+        .await
+        .unwrap();
 
     let mut bal = CHANNEL_BALANCE.lock().unwrap();
     *bal -= Amount::from_sat(payload.amount);


### PR DESCRIPTION
- Add new cashu_web module with maud HTML templates and axum server
- Implement two-step mint: quote generation → lightning invoice → completion
- Add CLI support for configurable mint URL via clap
- Add fixed corner balance display and clean up duplicate balance boxes
- Split mint functionality and add get_balance() method
- Create focused UI pages with minimal clutter and better UX